### PR TITLE
inbounds on code blocks

### DIFF
--- a/src/utils/matrix_utils.jl
+++ b/src/utils/matrix_utils.jl
@@ -1,7 +1,7 @@
 
 function istriustrict(A::Matrix)
     m, n = size(A)
-    for j = 1:min(n,m-1), i = j:m
+    @inbounds for j = 1:min(n,m-1), i = j:m
         if A[i,j] != 0.
             return false
         end
@@ -11,7 +11,7 @@ end
 
 function istrilstrict(A::Matrix)
     m, n = size(A)
-    for j = 2:n, i = 1:min(j,m)
+    @inbounds for j = 2:n, i = 1:min(j,m)
         if A[i,j] != 0.
             return false
         end
@@ -20,24 +20,24 @@ function istrilstrict(A::Matrix)
 end
 
 function simd_scale!(x, a)
-    @simd for i=1:length(x)
-        @inbounds x[i] *= a
+    @simd @inbounds for i=1:length(x)
+        x[i] *= a
     end
     nothing
 end
 
 function simd_copy!(x, y)
     @assert length(x) == length(y)
-    @simd for i=1:length(y)
-        @inbounds y[i] = x[i]
+    @simd @inbounds for i=1:length(y)
+        y[i] = x[i]
     end
     nothing
 end
 
 function simd_copy_scale!(a, x, y)
     @assert length(x) == length(y)
-    @simd for i=1:length(y)
-        @inbounds y[i] = a*x[i]
+    @simd @inbounds for i=1:length(y)
+        y[i] = a*x[i]
     end
     nothing
 end
@@ -45,8 +45,8 @@ end
 "Copy the first dimension of a 2D array y into a 1D array x."
 function simd_copy_xy_first!(x, y, j)
     @assert length(x) == size(y, 1)
-    @simd for i=1:length(x)
-        @inbounds x[i] = y[i,j]
+    @simd @inbounds for i=1:length(x)
+        x[i] = y[i,j]
     end
     nothing
 end
@@ -54,8 +54,8 @@ end
 "Copy the first dimension of a 3D array y into a 1D array x."
 function simd_copy_xy_first!(x, y, j, k)
     @assert length(x) == size(y, 1)
-    @simd for i=1:length(x)
-        @inbounds x[i] = y[i,j,k]
+    @simd @inbounds for i=1:length(x)
+        x[i] = y[i,j,k]
     end
     nothing
 end
@@ -63,8 +63,8 @@ end
 "Copy a 1D array x into the first dimension of a 2D array y."
 function simd_copy_yx_first!(x, y, j)
     @assert length(x) == size(y, 1)
-    @simd for i=1:size(y, 1)
-        @inbounds y[i,j] = x[i]
+    @simd @inbounds for i=1:size(y, 1)
+        y[i,j] = x[i]
     end
     nothing
 end
@@ -72,8 +72,8 @@ end
 "Copy a 1D array x into the first dimension of a 3D array y."
 function simd_copy_yx_first!(x, y, j, k)
     @assert length(x) == size(y, 1)
-    @simd for i=1:size(y, 1)
-        @inbounds y[i,j,k] = x[i]
+    @simd @inbounds for i=1:size(y, 1)
+        y[i,j,k] = x[i]
     end
     nothing
 end
@@ -81,9 +81,9 @@ end
 function simd_copy_yx_first_last!(x, y, j)
     @assert size(x, 1) == size(y, 1)
     @assert size(x, 2) == size(y, 3)
-    @simd for k=1:size(y, 3)
+    @simd @inbounds for k=1:size(y, 3)
         @simd for i=1:size(y, 1)
-            @inbounds y[i,j,k] = x[i,k]
+            y[i,j,k] = x[i,k]
         end
     end
     nothing
@@ -91,24 +91,24 @@ end
 
 function simd_xpy!(x, y)
     @assert length(x) == length(y)
-    @simd for i=1:length(y)
-        @inbounds y[i] += x[i]
+    @simd @inbounds for i=1:length(y)
+        y[i] += x[i]
     end
     nothing
 end
 
 function simd_axpy!(a, x, y)
     @assert length(x) == length(y)
-    @simd for i=1:length(y)
-        @inbounds y[i] += a*x[i]
+    @simd @inbounds for i=1:length(y)
+        y[i] += a*x[i]
     end
     nothing
 end
 
 function simd_wxpy!(w, x, y)
     @assert length(x) == length(y) == length(w)
-    @simd for i=1:length(w)
-        @inbounds w[i] = x[i] + y[i]
+    @simd @inbounds for i=1:length(w)
+        w[i] = x[i] + y[i]
     end
     nothing
 end
@@ -123,10 +123,10 @@ end
 function simd_mult!(w, X, y)
     @assert length(w) == size(X, 1)
     @assert length(y) == size(X, 2)
-    for i=1:length(w)
+    @inbounds for i=1:length(w)
         w[i] = 0.
         @simd for j=1:length(y)
-            @inbounds w[i] += X[i,j] * y[j]
+            w[i] += X[i,j] * y[j]
         end
     end
     nothing
@@ -135,10 +135,10 @@ end
 function simd_mult!(w, a, X, y)
     @assert length(w) == size(X, 1)
     @assert length(y) == size(X, 2)
-    @simd for i=1:length(w)
+    @simd @inbounds for i=1:length(w)
         w[i] = 0
         @simd for j=1:length(y)
-            @inbounds w[i] += a * X[i,j] * y[j]
+            w[i] += a * X[i,j] * y[j]
         end
     end
     nothing


### PR DESCRIPTION
Added inbounds to the first few functions, and moved the inbounds to the code blocks on others. Note that `@inbounds` propagates through for the whole code block so you can just put it on the `for` (but it doesn't propagate into functions!). Moving it like this also turned off inbounds checking on a few `w[i]` calls. Altogether, this likely won't affect performance much at all, but it makes it all more uniform.

Tests weren't run (do you have unit tests?)